### PR TITLE
Added wildcard to bika listing search

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -594,7 +594,7 @@ class BikaListingView(BrowserView):
                     continue
                 ##logger.info("Or: %s=%s"%(index, value))
                 if idx.meta_type in('ZCTextIndex', 'FieldIndex'):
-                    self.Or.append(MatchRegexp(index, value))
+                    self.Or.append(MatchRegexp(index, '%s*' % value))
                     self.expand_all_categories = True
                     # https://github.com/bikalabs/Bika-LIMS/issues/1069
                     vals = value.split('-')


### PR DESCRIPTION
Added a wildcard to listing search so that words starting with the given text will be matched. This does not solve the issues of (a) matches anywhere in the text or (b) numbers in the text.